### PR TITLE
Depedency javax.servlet-api added to the pom.xml file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,12 @@
       <version>3.8.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+	  <groupId>javax.servlet</groupId>
+	  <artifactId>javax.servlet-api</artifactId>
+	  <version>3.1.0</version>
+	  <scope>provided</scope>
+	</dependency>
   </dependencies>
   <build>
     <finalName>cluster-demo</finalName>


### PR DESCRIPTION
Before there was the error :
The superclass "javax.servlet.http.HttpServlet" was not found on the Java Build Path.
This is fixed.
